### PR TITLE
Support Alphanumeric lock ids

### DIFF
--- a/inc/locking.ps1
+++ b/inc/locking.ps1
@@ -59,7 +59,7 @@ function Get-Locked-Files {
     # Output is of the form (for owned)
     # O Path/To/File\tsteve\tID:268
     foreach ($line in $lfsLocksOutput) {
-        if ($line -match "^O ([^\t]+)\t+(.+)\s+ID:(\d+).*$") {
+        if ($line -match "^O ([^\t]+)\t+(.+)\s+ID:(\w+).*$") {
             $filename = $matches[1]
             $owner = $matches[2]
             $id = $matches[3]


### PR DESCRIPTION
Using Git LFS test server `git lfs locks --verify` returns something like this:

`O Content/MyAsset.uasset                           gkoreman        ID:b0dd4d1797411e59b5e208eca08e3152faa2026d`

Note that the ID is not just numbers, so the \d in the regex fails to match. Changing the regex to match on alphanumeric fixed the issue for me.